### PR TITLE
トピックごとのページ作成

### DIFF
--- a/app/controllers/TopicController.scala
+++ b/app/controllers/TopicController.scala
@@ -24,6 +24,14 @@ class TopicController @Inject() (implicit webJarAssets: WebJarAssets, val messag
     Ok(views.html.index(res, webJarAssets, Topic.findAll))
   }
 
+  def show(id: Long) = Action{
+    val res = "トピック"
+    Topic.find(id) match {
+      case Some(topic) => Ok(views.html.showTopic(res, webJarAssets, topic))
+      case None => NotFound("Not Found")
+    }
+  }
+
   def createFormView = Action {
     val res = "トピックの作成"
     Ok(views.html.create(res, createForm, webJarAssets))

--- a/app/models/topic.scala
+++ b/app/models/topic.scala
@@ -20,9 +20,9 @@ object Topic extends SQLSyntaxSupport[Topic]{
     Topic(id = id, name = name)
   }
 
-  def find(name: String)(implicit session: DBSession = autoSession):
+  def find(id: Long)(implicit session: DBSession = autoSession):
     Option[Topic] = {
-      withSQL { select.from(Topic as t).where.eq(t.name, name) }
+      withSQL { select.from(Topic as t).where.eq(t.id, id) }
         .map { rs => Topic(
           id = rs.long(t.resultName.id),
           name = rs.string(t.resultName.name)

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,23 +1,10 @@
-@*
- * This template takes a single argument, a String containing a
- * message to display.
- *@
 @(message: String, webJarAssets: WebJarAssets, topics: List[Topic])
 
-@*
- * Call the `main` template with two arguments. The first
- * argument is a `String` with the title of the page, the second
- * argument is an `Html` object containing the body of the page.
- *@
 @main("Welcome to Play", webJarAssets) {
 
-  <div class = "row">
-   <div class = "container">
      <h2>トピック一覧</h2>
      @for(topic <- topics) {
-       <p>@{topic.name}</p>
+       <a href='@{routes.TopicController.show(topic.id)}'><p>@{topic.name}</p></a>
      }
      <a href = "topic/create">トピックの作成</a>
-   </div>
-  </div>
 }

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -1,27 +1,22 @@
-@*
- * This template is called from the `index` template. This template
- * handles the rendering of the page header and body tags. It takes
- * two arguments, a `String` for the title of the page and an `Html`
- * object to insert into the body of the page.
- *@
 @(title: String, webJarAssets: WebJarAssets)(content: Html)
 
 <!DOCTYPE html>
 <html lang="ja">
-    <head>
-        @* Here's where we render the page title `String`. *@
-        <title>@title</title>
-        <link rel="stylesheet" media="screen" href="@routes.Assets.versioned("stylesheets/main.css")">
-        <link rel="stylesheet" href="@routes.WebJarAssets.at(webJarAssets.locate("css/bootstrap.min.css"))">
-        <link rel="shortcut icon" type="image/png" href='@routes.Assets.versioned("images/favicon.png")'>
-        <script src=""@routes.Assets.versioned("javascripts/hello.js")" type="text/javascript"></script>
-    </head>
-    <body>
-      <header>
-        <h1>掲示板</h1>
-      </header>
-        <div class = "container">
-          @content
-        </div>
-    </body>
+  <head>
+    <title>@title</title>
+    <link rel="stylesheet" media="screen" href="@routes.Assets.versioned("stylesheets/main.css")">
+    <link rel="stylesheet" href="@routes.WebJarAssets.at(webJarAssets.locate("css/bootstrap.min.css"))">
+    <link rel="shortcut icon" type="image/png" href='@routes.Assets.versioned("images/favicon.png")'>
+    <script src=""@routes.Assets.versioned("javascripts/hello.js")" type="text/javascript"></script>
+  </head>
+  <body>
+    <header>
+      <h1>掲示板</h1>
+    </header>
+     <div class = "row">
+      <div class = "container">
+        @content
+      </div>
+     </div>
+  </body>
 </html>

--- a/app/views/showTopic.scala.html
+++ b/app/views/showTopic.scala.html
@@ -1,0 +1,7 @@
+@(message: String, webJarAssets: WebJarAssets, topic: Topic)
+
+@main("Welcome to Play", webJarAssets) {
+
+  <p>@topic.name</p>
+  <h2>投稿一覧</h2>
+}

--- a/conf/routes
+++ b/conf/routes
@@ -16,5 +16,6 @@ GET     /assets/*file               controllers.Assets.versioned(path="/public",
 GET     /webjars/*file              controllers.WebJarAssets.at(file)
 
 # create topic
-GET     /topic/create            controllers.TopicController.createFormView
-POST    /topic/create            controllers.TopicController.create
+GET     /topic/create               controllers.TopicController.createFormView
+POST    /topic/create               controllers.TopicController.create
+GET     /topic/:id                  controllers.TopicController.show(id: Long)


### PR DESCRIPTION
# REF
https://github.com/Hiroki6/BulletinBoard/issues/4

# WHY

トピックごとのページを作成したい

# WHAT

以下の実装によって実現した

### models/Topic.findの変更

トピックのidからトピックを検索できるようにfindメソッドを変更した

```scala:Topic.scala
def find(id: Long)(implicit session: DBSession = autoSession):
    Option[Topic] = {
      withSQL { select.from(Topic as t).where.eq(t.id, id) }
        .map { rs => Topic(
          id = rs.long(t.resultName.id),
          name = rs.string(t.resultName.name)
        )
        }.single.apply()
  }
```

### controllers/TopicController.showの実装

viewから渡ったトピックのidを基にトピックのページを作成するshowメソッドを作成した

```scala:TopicController.scala
def show(id: Long) = Action{
    val res = "トピック"
    Topic.find(id) match {
      case Some(topic) => Ok(views.html.showTopic(res, webJarAssets, topic))
      case None => NotFound("Not Found")
    }
  }
```

### views/showTopic.scala.htmlの実装

トピックごとのページを表示するshowTopic.scala.htmlを作成した

```html:showTopic.scala.html
<p>@topic.name</p>
  <h2>投稿一覧</h2>
```