### PR TITLE
投稿一覧取得

### DIFF
--- a/app/controllers/TopicController.scala
+++ b/app/controllers/TopicController.scala
@@ -19,22 +19,10 @@ class TopicController @Inject() (implicit webJarAssets: WebJarAssets, val messag
     )(TopicForm.apply)(TopicForm.unapply)
   )
 
-  /*def index = Action {
-    val res = "トピック一覧"
-    Ok(views.html.index(res, webJarAssets, Topic.findAll))
-  }*/
-
   def createTopic = Action {
     val res = "トピックの作成"
     Ok(views.html.createTopic(res, topicForm, webJarAssets))
   }
-  /*def show(id: Long) = Action {
-    val res = "トピック"
-    Topic.find(id) match {
-      case Some(topic) => Ok(views.html.topic(res, postForm, webJarAssets, topic))
-      case None => NotFound("Not Found")
-    }
-  }*/
 
   def create = Action { implicit request =>
     topicForm.bindFromRequest.fold(

--- a/app/controllers/TopicPostController.scala
+++ b/app/controllers/TopicPostController.scala
@@ -15,21 +15,29 @@ class TopicPostController @Inject() (implicit webJarAssets: WebJarAssets, val me
 
   val postForm = Form(
     mapping(
-      "content" -> text
+      "新規投稿" -> text
     )(PostForm.apply)(PostForm.unapply)
   )
+
+  /*def show(id: Long) = Action {
+    val res = "トピック"
+    Topic.find(id) match {
+      case Some(topic) => Ok(views.html.topic(res, postForm, webJarAssets, topic))
+      case None => NotFound("Not Found")
+    }
+  }*/
 
   def show(id: Long) = Action {
     val res = "トピック"
     Topic.find(id) match {
-      case Some(topic) => Ok(views.html.topic(res, postForm, webJarAssets, topic))
+      case Some(topic) => Ok(views.html.topic(res, postForm, webJarAssets, topic, TopicPost.findByTopicId(id)))
       case None => NotFound("Not Found")
     }
   }
 
   def create(id: Long) = Action { implicit request =>
    postForm.bindFromRequest.fold(
-      error => BadRequest(postForm.bindFromRequest.error("content").get.message),
+      error => BadRequest(postForm.bindFromRequest.error("新規投稿").get.message),
       form => {
         TopicPost.create(content = form.content, topic_id = id)
         Redirect(routes.TopicPostController.show(id))

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -5,8 +5,8 @@
 
    <h2>トピック一覧</h2>
    @for(topic <- topics) {
-     <a href='@{routes.TopicPostController.show(topic.id)}'><p>@{topic.name}</p></a>
+     <h3><a href='@{routes.TopicPostController.show(topic.id)}'>@{topic.name}</a></h3>
    }
-   <a href="topic/create">トピックの作成</a>
+   <a href="topic/create">トピックを作成する</a>
 
 }

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     <header>
-      <h1>掲示板</h1>
+      <h1><a href = "/">掲示板</a></h1>
     </header>
      <div class = "row">
       <div class = "container">

--- a/app/views/topic.scala.html
+++ b/app/views/topic.scala.html
@@ -1,13 +1,16 @@
-@(message: String, postForm: Form[PostForm], webJarAssets: WebJarAssets, topic: Topic)(implicit messages: Messages)
+@(message: String, postForm: Form[PostForm], webJarAssets: WebJarAssets, topic: Topic, posts: List[TopicPost])(implicit messages: Messages)
 
 @import helper._
 @main("Welcome to Play", webJarAssets) {
 
   <h2>トピック: @topic.name</h2>
   <h3>投稿一覧</h3>
+  @for(post <- posts) {
+    <p>@{post.content}</p>
+  }
   <div class = "post-form">
     @form(action = routes.TopicPostController.create(topic.id)){
-    @textarea(postForm("content"))
+    @textarea(postForm("新規投稿"))
     <input type = "submit" value="投稿する">
     }
   </div>

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -1,13 +1,21 @@
-html, body{
+html, body {
   margin: 0;
 }
 
-header{
+header {
   background-color: #7fffd4;
   padding: 5px 30px;
 }
 
-.post-form textarea{
+header a {
+  color: #000;
+}
+
+header a:hover {
+  text-decoration: none;
+}
+
+.post-form textarea {
   width: 300px;
   height: 100px;
 }


### PR DESCRIPTION
# REF
https://github.com/Hiroki6/BulletinBoard/issues/4

# WHY

トピックごとのページでそのトピックについての投稿を全て取得したい

# WHAT

以下の実装を行って実現した
### models/TopicPost.findByTopicIdの作成

指定したトピックのidからそれに紐付いた投稿をすべて取得するfindByTopicIdを作成した

```scala
 def findByTopicId(topic_id: Long)(implicit session: DBSession = autoSession):
    List[TopicPost] = {
      withSQL { select.from(TopicPost as p).where.eq(p.topic_id, topic_id) }
        .map { rs => TopicPost(
          id = rs.long(p.resultName.id),
          content = rs.string(p.resultName.content),
          topic_id = rs.long(p.resultName.topic_id)
        )
        }.list.apply()
  }
```

### controllers/TopicPostController.showの変更

TopicPost.findByTopicIdメソッドを呼び出し、viewに渡すように変更した

```scala
def show(id: Long) = Action {
    val res = "トピック"
    Topic.find(id) match {
      case Some(topic) => Ok(views.html.topic(res, postForm, webJarAssets, topic, TopicPost.findByTopicId(id)))
      case None => NotFound("Not Found")
    }
  }
```

### views/topic.scala.htmlの変更

controllerから渡されたposts: List[TopicPost]を出力するようにした

```index
<h3>投稿一覧</h3>
  @for(post <- posts) {
    <p>@{post.content}</p>
  }
```