### PR TITLE
modelにapplyメソッドを適用

### DIFF
--- a/app/models/PostComment.scala
+++ b/app/models/PostComment.scala
@@ -11,6 +11,9 @@ object PostComment extends SQLSyntaxSupport[PostComment]{
 
   val c = PostComment.syntax("c")
 
+  def apply(c: ResultName[PostComment])(rs: WrappedResultSet): PostComment =
+    PostComment(rs.long(c.id), rs.string(c.content), rs.long(c.post_id))
+
   def create(content: String, post_id: Long)(implicit session: DBSession = autoSession):
   PostComment = {
     val id = withSQL {
@@ -25,12 +28,7 @@ object PostComment extends SQLSyntaxSupport[PostComment]{
   def findByPostId(post_id: Long)(implicit session: DBSession = autoSession):
   List[PostComment] = {
     withSQL { select.from(PostComment as c).where.eq(c.post_id, post_id) }
-      .map { rs => PostComment(
-        id = rs.long(c.resultName.id),
-        content = rs.string(c.resultName.content),
-        post_id = rs.long(c.resultName.post_id)
-      )
-      }.list.apply()
+      .map(PostComment(c.resultName)).list.apply()
   }
 }
 

--- a/app/models/TopicPost.scala
+++ b/app/models/TopicPost.scala
@@ -11,6 +11,9 @@ object TopicPost extends SQLSyntaxSupport[TopicPost]{
 
   val p = TopicPost.syntax("p")
 
+  def apply(p: ResultName[TopicPost])(rs: WrappedResultSet): TopicPost =
+    TopicPost(rs.long(p.id), rs.string(p.content), rs.long(p.topic_id))
+
   def create(content: String, topic_id: Long)(implicit session: DBSession = autoSession):
     TopicPost = {
       val id = withSQL {
@@ -25,23 +28,13 @@ object TopicPost extends SQLSyntaxSupport[TopicPost]{
   def find(id: Long)(implicit session: DBSession = autoSession):
   Option[TopicPost] = {
     withSQL { select.from(TopicPost as p).where.eq(p.id, id) }
-      .map { rs => TopicPost(
-        id = rs.long(p.resultName.id),
-        content = rs.string(p.resultName.content),
-        topic_id = rs.long(p.resultName.topic_id)
-      )
-      }.single.apply()
+      .map(TopicPost(p.resultName)).single.apply()
   }
 
   def findByTopicId(topic_id: Long)(implicit session: DBSession = autoSession):
     List[TopicPost] = {
       withSQL { select.from(TopicPost as p).where.eq(p.topic_id, topic_id) }
-        .map { rs => TopicPost(
-          id = rs.long(p.resultName.id),
-          content = rs.string(p.resultName.content),
-          topic_id = rs.long(p.resultName.topic_id)
-        )
-        }.list.apply()
+        .map(TopicPost(p.resultName)).list.apply()
   }
 }
 

--- a/app/models/topic.scala
+++ b/app/models/topic.scala
@@ -10,6 +10,9 @@ object Topic extends SQLSyntaxSupport[Topic]{
   override val columns = Seq("id", "name")
 
   val t = Topic.syntax("t")
+
+  def apply(t: ResultName[Topic])(rs: WrappedResultSet): Topic = Topic(rs.long(t.id), rs.string(t.name))
+
   def create(name: String)(implicit session: DBSession = autoSession):
     Topic = {
       val id = withSQL {
@@ -21,23 +24,15 @@ object Topic extends SQLSyntaxSupport[Topic]{
     }
 
   def find(id: Long)(implicit session: DBSession = autoSession):
-  Option[Topic] = {
-    withSQL { select.from(Topic as t).where.eq(t.id, id) }
-      .map { rs => Topic(
-        id = rs.long(t.resultName.id),
-        name = rs.string(t.resultName.name)
-      )
-      }.single.apply()
+    Option[Topic] = {
+      withSQL { select.from(Topic as t).where.eq(t.id, id) }
+        .map(Topic(t.resultName)).single.apply()
   }
 
   def findAll()(implicit session: DBSession = autoSession):
     List[Topic] = {
       withSQL { select.from(Topic as t) }
-        .map { rs => Topic(
-          id = rs.long(t.resultName.id),
-          name = rs.string(t.resultName.name)
-          )
-        }.list.apply()
+        .map(Topic(t.resultName)).list.apply()
     }
 }
 


### PR DESCRIPTION
# WHY
findメソッドなどを使う際に、mapで全てのカラムを書いていたので

# WHAT

applyメソッドを定義して短く書けるようにした

```scala
def apply(t: ResultName[Topic])(rs: WrappedResultSet): Topic = Topic(rs.long(t.id), rs.string(t.name))

withSQL { select.from(Topic as t).where.eq(t.id, id) }
        .map(Topic(t.resultName)).single.apply()
```
