### PR TITLE
トピック削除機能追加

### DIFF
--- a/app/controllers/TopicController.scala
+++ b/app/controllers/TopicController.scala
@@ -34,4 +34,10 @@ class TopicController @Inject() (implicit webJarAssets: WebJarAssets, val messag
     )
   }
 
+  def delete(id: Long) = Action {
+    TopicPost.deleteByTopicId(id)
+    Topic.delete(id)
+    Redirect(routes.HomeController.index)
+  }
+
 }

--- a/app/controllers/TopicController.scala
+++ b/app/controllers/TopicController.scala
@@ -35,9 +35,15 @@ class TopicController @Inject() (implicit webJarAssets: WebJarAssets, val messag
   }
 
   def delete(id: Long) = Action {
-    TopicPost.deleteByTopicId(id)
-    Topic.delete(id)
-    Redirect(routes.HomeController.index)
+    PostComment.countByTopicId(id) match {
+      case 0 => {
+        TopicPost.deleteByTopicId(id)
+        Topic.delete(id)
+        Redirect(routes.HomeController.index)
+      }
+      case _ => BadRequest("このトピックにコメントがあるため削除できません")
+    }
+
   }
 
 }

--- a/app/controllers/TopicPostController.scala
+++ b/app/controllers/TopicPostController.scala
@@ -30,7 +30,7 @@ class TopicPostController @Inject() (implicit webJarAssets: WebJarAssets, val me
    postForm.bindFromRequest.fold(
       error => BadRequest(postForm.bindFromRequest.error("新規投稿").get.message),
       form => {
-        TopicPost.create(content = form.content, topic_id = id)
+        TopicPost.create(content = form.content, topicId = id)
         Redirect(routes.TopicPostController.show(id))
       }
     )

--- a/app/models/PostComment.scala
+++ b/app/models/PostComment.scala
@@ -10,6 +10,7 @@ object PostComment extends SQLSyntaxSupport[PostComment]{
   override val columns = Seq("id", "content", "post_id")
 
   val c = PostComment.syntax("c")
+  val p = TopicPost.p
 
   def apply(c: ResultName[PostComment])(rs: WrappedResultSet): PostComment =
     PostComment(rs.long(c.id), rs.string(c.content), rs.long(c.post_id))
@@ -30,5 +31,13 @@ object PostComment extends SQLSyntaxSupport[PostComment]{
     withSQL { select.from(PostComment as c).where.eq(c.post_id, post_id) }
       .map(PostComment(c.resultName)).list.apply()
   }
+
+  def countByTopicId(topicId: Long)(implicit session: DBSession = autoSession):
+    Long = {
+      withSQL {
+        select(sqls.count).from(PostComment as c).where.in(c.post_id,
+          (select(p.result.id).from(TopicPost as p).where.eq(p.topic_id, topicId)))
+      }.map(_.long(1)).single.apply().get
+    }
 }
 

--- a/app/models/TopicPost.scala
+++ b/app/models/TopicPost.scala
@@ -14,27 +14,33 @@ object TopicPost extends SQLSyntaxSupport[TopicPost]{
   def apply(p: ResultName[TopicPost])(rs: WrappedResultSet): TopicPost =
     TopicPost(rs.long(p.id), rs.string(p.content), rs.long(p.topic_id))
 
-  def create(content: String, topic_id: Long)(implicit session: DBSession = autoSession):
+  def create(content: String, topicId: Long)(implicit session: DBSession = autoSession):
     TopicPost = {
       val id = withSQL {
         insert.into(TopicPost).namedValues(
           column.content -> content,
-          column.topic_id -> topic_id
+          column.topic_id -> topicId
         )
       }.updateAndReturnGeneratedKey.apply()
-      TopicPost(id = id, content = content, topic_id = topic_id)
+      TopicPost(id = id, content = content, topic_id = topicId)
     }
 
   def find(id: Long)(implicit session: DBSession = autoSession):
-  Option[TopicPost] = {
-    withSQL { select.from(TopicPost as p).where.eq(p.id, id) }
-      .map(TopicPost(p.resultName)).single.apply()
-  }
+    Option[TopicPost] = {
+      withSQL { select.from(TopicPost as p).where.eq(p.id, id) }
+        .map(TopicPost(p.resultName)).single.apply()
+    }
 
-  def findByTopicId(topic_id: Long)(implicit session: DBSession = autoSession):
+  def findByTopicId(topicId: Long)(implicit session: DBSession = autoSession):
     List[TopicPost] = {
-      withSQL { select.from(TopicPost as p).where.eq(p.topic_id, topic_id) }
+      withSQL { select.from(TopicPost as p).where.eq(p.topic_id, topicId) }
         .map(TopicPost(p.resultName)).list.apply()
+    }
+
+  def deleteByTopicId(topicId: Long)(implicit session: DBSession = autoSession) {
+    withSQL {
+      delete.from(TopicPost).where.eq(TopicPost.column.topic_id, topicId)
+    }.update.apply()
   }
 }
 

--- a/app/models/topic.scala
+++ b/app/models/topic.scala
@@ -27,12 +27,19 @@ object Topic extends SQLSyntaxSupport[Topic]{
     Option[Topic] = {
       withSQL { select.from(Topic as t).where.eq(t.id, id) }
         .map(Topic(t.resultName)).single.apply()
-  }
+    }
 
   def findAll()(implicit session: DBSession = autoSession):
     List[Topic] = {
       withSQL { select.from(Topic as t) }
         .map(Topic(t.resultName)).list.apply()
     }
+
+  def delete(id: Long)(implicit session: DBSession = autoSession) {
+    withSQL {
+      deleteFrom(Topic).where.eq(Topic.column.id, id)
+    }.update.apply()
+  }
+
 }
 

--- a/app/views/post.scala.html
+++ b/app/views/post.scala.html
@@ -10,8 +10,8 @@
   }
   <div class = "post-form">
     @form(action = routes.PostCommentController.create(post.id)){
-    @textarea(commentForm("新規コメント"))
-    <input type = "submit" value="コメントする">
+      @textarea(commentForm("新規コメント"))
+      <input type = "submit" value="コメントする">
     }
   </div>
 

--- a/app/views/topic.scala.html
+++ b/app/views/topic.scala.html
@@ -11,8 +11,11 @@
   }
   <div class = "post-form">
     @form(action = routes.TopicPostController.create(topic.id)){
-    @textarea(postForm("新規投稿"))
-    <input type = "submit" value="投稿する">
+      @textarea(postForm("新規投稿"))
+      <input type = "submit" value="投稿する">
     }
   </div>
+  @form(action=routes.TopicController.delete(topic.id)){
+    <input type = "submit" value="トピックを削除する">
+  }
 }

--- a/conf/routes
+++ b/conf/routes
@@ -13,6 +13,7 @@ GET     /webjars/*file              controllers.WebJarAssets.at(file)
 # create topic
 GET     /topic/create               controllers.TopicController.createTopic
 POST    /topic/create               controllers.TopicController.create
+POST  /topic/:id/delete             controllers.TopicController.delete(id: Long)
 
 GET     /topic/:id                  controllers.TopicPostController.show(id: Long)
 POST    /topic/:id                  controllers.TopicPostController.create(id: Long)


### PR DESCRIPTION
# WHY

コメントがないトピックを削除できるようにしたい

# WHAT

以下の実装を行い実現した

### models/PostComment.countByTopicIdメソッドの作成

そのトピックに対する投稿について全てのコメントの数を数えるcountByTopicIdメソッドを作成した

```scala
def countByTopicId(topicId: Long)(implicit session: DBSession = autoSession):
    Long = {
      withSQL {
        select(sqls.count).from(PostComment as c).where.in(c.post_id,
          (select(p.result.id).from(TopicPost as p).where.eq(p.topic_id, topicId)))
      }.map(_.long(1)).single.apply().get
    }
```

### models/TopicPost.deleteByTopicIdメソッドの作成a

そのトピックに対する投稿をすべて削除するdeleteByTopicIdメソッドを作成した

```scala
def deleteByTopicId(topicId: Long)(implicit session: DBSession = autoSession) {
    withSQL {
      delete.from(TopicPost).where.eq(TopicPost.column.topic_id, topicId)
    }.update.apply()
  }
```

### models/Topic.deleteメソッドの作成

トピックを削除するdeleteメソッドを作成した

```scala
def delete(id: Long)(implicit session: DBSession = autoSession) {
    withSQL {
      deleteFrom(Topic).where.eq(Topic.column.id, id)
    }.update.apply()
  }
```

### views/topic.scala.htmlの変更

トピック削除フォームをtopic.scala.htmlに追加した
```html
@form(action=routes.TopicController.delete(topic.id)){
    <input type = "submit" value="トピックを削除する">
  }
```

### controllers/TopicController.deleteメソッドの作成

そのトピック上にコメントがなければ投稿とトピックを削除し、コメントがあれば削除できないようにした

```scala
def delete(id: Long) = Action {
    PostComment.countByTopicId(id) match {
      case 0 => {
        TopicPost.deleteByTopicId(id)
        Topic.delete(id)
        Redirect(routes.HomeController.index)
      }
      case _ => BadRequest("このトピックにコメントがあるため削除できません")
    }
  }
```